### PR TITLE
Fix experimental_options for memcache config.

### DIFF
--- a/templates/init_systemd.erb
+++ b/templates/init_systemd.erb
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/memcached -d \
   -l <%= @listen %> \
   -c <%= @maxconn %> \
   -I <%= @max_object_size %><% if @experimental_options.any? %> \
-  -o <%= @experimental_options.join(', ') %><% end %><% if @threads %> \
+  -o <%= @experimental_options.join(',') %><% end %><% if @threads %> \
   -t <%= @threads %><% end %>
 
 [Install]

--- a/templates/init_sysv.erb
+++ b/templates/init_sysv.erb
@@ -51,7 +51,7 @@ start () {
           -l <%= @listen %> \
           -c <%= @maxconn %> \
           -I <%= @max_object_size %><% if @experimental_options.any? %> \
-          -o <%= @experimental_options.join(', ') %><% end %><% if @threads %> \
+          -o <%= @experimental_options.join(',') %><% end %><% if @threads %> \
           -t <%= @threads %><% end %>
         RETVAL=$?
         echo

--- a/templates/init_upstart.erb
+++ b/templates/init_upstart.erb
@@ -13,5 +13,5 @@ exec /usr/bin/memcached -d \
   -l <%= @listen %> \
   -c <%= @maxconn %> \
   -I <%= @max_object_size %><% if @experimental_options.any? %> \
-  -o <%= @experimental_options.join(', ') %><% end %><% if @threads %> \
+  -o <%= @experimental_options.join(',') %><% end %><% if @threads %> \
   -t <%= @threads %><% end %>

--- a/templates/sv-memcached-run.erb
+++ b/templates/sv-memcached-run.erb
@@ -14,6 +14,6 @@ exec chpst -u <%= @options[:user] %> \
   -l <%= @options[:listen] %> \
   -c <%= @options[:maxconn] %> \
   -I <%= @options[:max_object_size] %><% if @options[:experimental_options].any? %> \
-  -o <%= @options[:experimental_options].join(', ') %><% end %><% if @options[:threads] %> \
+  -o <%= @options[:experimental_options].join(',') %><% end %><% if @options[:threads] %> \
   -t <%= @options[:threads] %>
   <% end %>


### PR DESCRIPTION
Before, a whitespace was introduced between each options,
preventing memcached to parse correctly the arguments and
ignoring all but the first experimental option.
