### PR TITLE
Add a stopDelay attribute for the systemd resource

### DIFF
--- a/resources/instance_systemd.rb
+++ b/resources/instance_systemd.rb
@@ -26,6 +26,7 @@ property :ulimit, [Integer, String]
 property :template_cookbook, String, default: 'memcached'
 property :disable_default_instance, [TrueClass, FalseClass], default: true
 property :remove_default_config, [TrueClass, FalseClass], default: true
+property :stopDelay, Integer
 
 action :start do
   create_init
@@ -95,7 +96,8 @@ action_class.class_eval do
         threads: new_resource.threads,
         max_object_size: new_resource.max_object_size,
         experimental_options: new_resource.experimental_options,
-        ulimit: new_resource.ulimit
+        ulimit: new_resource.ulimit,
+        stopDelay: new_resource.stopDelay
       )
       cookbook 'memcached'
       notifies :restart, "service[#{memcached_instance_name}]", :immediately

--- a/templates/init_systemd.erb
+++ b/templates/init_systemd.erb
@@ -17,6 +17,11 @@ ExecStart=/usr/bin/memcached -d \
   -I <%= @max_object_size %><% if @experimental_options.any? %> \
   -o <%= @experimental_options.join(', ') %><% end %><% if @threads %> \
   -t <%= @threads %><% end %>
+<% if @stopDelay %>
+ExecStop=/bin/echo "Stop is delayed for <%= @stopDelay %> seconds. This allows a monitoring tool based on `systemctl is-active` to unregister the service before it is effectively shutting down."
+ExecStop=/bin/sh -c "sleep <%= @stopDelay %>"
+TimeoutStopSec=<%= @stopDelay + 30 %>
+<% end %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- add an optional attribute 'stopDelay' to delay `systemctl stop ...`.
This allows a monitoring based on `systemctl is-active` to unregister
the service from a registry BEFORE the service is effectively down
(`systemctl is-active ...` prints "deactivating" and returns
>0 exit code). When stopDelay is undefined or ZERO, the service
is unchanged (to not trigger a service restart...)

